### PR TITLE
add .net core version

### DIFF
--- a/CSharp/netcore2/Game.cs
+++ b/CSharp/netcore2/Game.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Trivia
+{
+    public class Game
+    {
+
+
+        List<string> players = new List<string>();
+
+        int[] places = new int[6];
+        int[] purses = new int[6];
+
+        bool[] inPenaltyBox = new bool[6];
+
+        LinkedList<string> popQuestions = new LinkedList<string>();
+        LinkedList<string> scienceQuestions = new LinkedList<string>();
+        LinkedList<string> sportsQuestions = new LinkedList<string>();
+        LinkedList<string> rockQuestions = new LinkedList<string>();
+
+        int currentPlayer = 0;
+        bool isGettingOutOfPenaltyBox;
+
+        public Game()
+        {
+            for (int i = 0; i < 50; i++)
+            {
+                popQuestions.AddLast("Pop Question " + i);
+                scienceQuestions.AddLast(("Science Question " + i));
+                sportsQuestions.AddLast(("Sports Question " + i));
+                rockQuestions.AddLast(CreateRockQuestion(i));
+            }
+        }
+
+        public String CreateRockQuestion(int index)
+        {
+            return "Rock Question " + index;
+        }
+
+        public bool IsPlayable()
+        {
+            return (HowManyPlayers() >= 2);
+        }
+
+        public bool Add(String playerName)
+        {
+
+
+            players.Add(playerName);
+            places[HowManyPlayers()] = 0;
+            purses[HowManyPlayers()] = 0;
+            inPenaltyBox[HowManyPlayers()] = false;
+
+            Console.WriteLine(playerName + " was Added");
+            Console.WriteLine("They are player number " + players.Count);
+            return true;
+        }
+
+        public int HowManyPlayers()
+        {
+            return players.Count;
+        }
+
+        public void Roll(int roll)
+        {
+            Console.WriteLine(players[currentPlayer] + " is the current player");
+            Console.WriteLine("They have rolled a " + roll);
+
+            if (inPenaltyBox[currentPlayer])
+            {
+                if (roll % 2 != 0)
+                {
+                    isGettingOutOfPenaltyBox = true;
+
+                    Console.WriteLine(players[currentPlayer] + " is getting out of the penalty box");
+                    places[currentPlayer] = places[currentPlayer] + roll;
+                    if (places[currentPlayer] > 11) places[currentPlayer] = places[currentPlayer] - 12;
+
+                    Console.WriteLine(players[currentPlayer]
+                            + "'s new location is "
+                            + places[currentPlayer]);
+                    Console.WriteLine("The category is " + CurrentCategory());
+                    AskQuestion();
+                }
+                else
+                {
+                    Console.WriteLine(players[currentPlayer] + " is not getting out of the penalty box");
+                    isGettingOutOfPenaltyBox = false;
+                }
+
+            }
+            else
+            {
+
+                places[currentPlayer] = places[currentPlayer] + roll;
+                if (places[currentPlayer] > 11) places[currentPlayer] = places[currentPlayer] - 12;
+
+                Console.WriteLine(players[currentPlayer]
+                        + "'s new location is "
+                        + places[currentPlayer]);
+                Console.WriteLine("The category is " + CurrentCategory());
+                AskQuestion();
+            }
+
+        }
+
+        private void AskQuestion()
+        {
+            if (CurrentCategory() == "Pop")
+            {
+                Console.WriteLine(popQuestions.First());
+                popQuestions.RemoveFirst();
+            }
+            if (CurrentCategory() == "Science")
+            {
+                Console.WriteLine(scienceQuestions.First());
+                scienceQuestions.RemoveFirst();
+            }
+            if (CurrentCategory() == "Sports")
+            {
+                Console.WriteLine(sportsQuestions.First());
+                sportsQuestions.RemoveFirst();
+            }
+            if (CurrentCategory() == "Rock")
+            {
+                Console.WriteLine(rockQuestions.First());
+                rockQuestions.RemoveFirst();
+            }
+        }
+
+
+        private String CurrentCategory()
+        {
+            if (places[currentPlayer] == 0) return "Pop";
+            if (places[currentPlayer] == 4) return "Pop";
+            if (places[currentPlayer] == 8) return "Pop";
+            if (places[currentPlayer] == 1) return "Science";
+            if (places[currentPlayer] == 5) return "Science";
+            if (places[currentPlayer] == 9) return "Science";
+            if (places[currentPlayer] == 2) return "Sports";
+            if (places[currentPlayer] == 6) return "Sports";
+            if (places[currentPlayer] == 10) return "Sports";
+            return "Rock";
+        }
+
+        public bool WasCorrectlyAnswered()
+        {
+            if (inPenaltyBox[currentPlayer])
+            {
+                if (isGettingOutOfPenaltyBox)
+                {
+                    Console.WriteLine("Answer was correct!!!!");
+                    purses[currentPlayer]++;
+                    Console.WriteLine(players[currentPlayer]
+                            + " now has "
+                            + purses[currentPlayer]
+                            + " Gold Coins.");
+
+                    bool winner = DidPlayerWin();
+                    currentPlayer++;
+                    if (currentPlayer == players.Count) currentPlayer = 0;
+
+                    return winner;
+                }
+                else
+                {
+                    currentPlayer++;
+                    if (currentPlayer == players.Count) currentPlayer = 0;
+                    return true;
+                }
+
+
+
+            }
+            else
+            {
+
+                Console.WriteLine("Answer was corrent!!!!");
+                purses[currentPlayer]++;
+                Console.WriteLine(players[currentPlayer]
+                        + " now has "
+                        + purses[currentPlayer]
+                        + " Gold Coins.");
+
+                bool winner = DidPlayerWin();
+                currentPlayer++;
+                if (currentPlayer == players.Count) currentPlayer = 0;
+
+                return winner;
+            }
+        }
+
+        public bool WrongAnswer()
+        {
+            Console.WriteLine("Question was incorrectly answered");
+            Console.WriteLine(players[currentPlayer] + " was sent to the penalty box");
+            inPenaltyBox[currentPlayer] = true;
+
+            currentPlayer++;
+            if (currentPlayer == players.Count) currentPlayer = 0;
+            return true;
+        }
+
+
+        private bool DidPlayerWin()
+        {
+            return !(purses[currentPlayer] == 6);
+        }
+    }
+
+}

--- a/CSharp/netcore2/GameRunner.cs
+++ b/CSharp/netcore2/GameRunner.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace Trivia
+{
+    public class GameRunner
+    {
+
+        private static bool notAWinner;
+
+        public static void Main(String[] args)
+        {
+            Game aGame = new Game();
+
+            aGame.Add("Chet");
+            aGame.Add("Pat");
+            aGame.Add("Sue");
+
+            Random rand = new Random();
+
+            do
+            {
+
+                aGame.Roll(rand.Next(5) + 1);
+
+                if (rand.Next(9) == 7)
+                {
+                    notAWinner = aGame.WrongAnswer();
+                }
+                else
+                {
+                    notAWinner = aGame.WasCorrectlyAnswered();
+                }
+
+
+
+            } while (notAWinner);
+
+        }
+
+
+    }
+
+}

--- a/CSharp/netcore2/README.md
+++ b/CSharp/netcore2/README.md
@@ -1,0 +1,22 @@
+This version is running with [dotnet](https://www.microsoft.com/net) >= 2.0
+
+The test script is changed to not contain illegal input, however the
+test reference file is not changed. So once you get the test running it
+will fail. You'll have to just validate the new result as the reference
+result. I don't have an environment to do it.
+Some method names have been renamed to comply with default PascalCase C# style guide
+
+The code uses [Assent](https://github.com/droyad/Assent), which means that
+when the test fails it will open up a diff-tool to compare the files
+*TriviaTests.RefactoringTests.approved.txt* and the result of the run
+*TriviaTests.RefactoringTests.received.txt*
+
+If you're using CLI tools :
+- installing required dependencies:
+```
+dotnet restore
+```
+- running tests and opening (default) diff tools:
+```
+dotnet test
+```

--- a/CSharp/netcore2/TriviaTests.RefactoringTests.approved.txt
+++ b/CSharp/netcore2/TriviaTests.RefactoringTests.approved.txt
@@ -1,0 +1,110 @@
+﻿False
+Chet was added
+They are player number 1
+Chet is the current player
+They have rolled a 1
+Chet's new location is 1
+The category is Science
+Science Question 0
+Chet is the current player
+They have rolled a 1
+Chet's new location is 2
+The category is Sports
+Sports Question 0
+Chet is the current player
+They have rolled a 1
+Chet's new location is 3
+The category is Rock
+Rock Question 0
+Chet is the current player
+They have rolled a 1
+Chet's new location is 4
+The category is Pop
+Pop Question 0
+Chet is the current player
+They have rolled a 1
+Chet's new location is 5
+The category is Science
+Science Question 1
+Chet is the current player
+They have rolled a 1
+Chet's new location is 6
+The category is Sports
+Sports Question 1
+Chet is the current player
+They have rolled a 1
+Chet's new location is 7
+The category is Rock
+Rock Question 1
+Chet is the current player
+They have rolled a 1
+Chet's new location is 8
+The category is Pop
+Pop Question 1
+Chet is the current player
+They have rolled a 1
+Chet's new location is 9
+The category is Science
+Science Question 2
+Chet is the current player
+They have rolled a 1
+Chet's new location is 10
+The category is Sports
+Sports Question 2
+Chet is the current player
+They have rolled a 1
+Chet's new location is 11
+The category is Rock
+Rock Question 2
+Chet is the current player
+They have rolled a 1
+Chet's new location is 0
+The category is Pop
+Pop Question 2
+Chet is the current player
+They have rolled a 1
+Chet's new location is 1
+The category is Science
+Science Question 3
+Chet is the current player
+They have rolled a 1
+Chet's new location is 2
+The category is Sports
+Sports Question 3
+Answer was correct!!!!
+Chet now has 1 Gold Coins.
+Question was incorrectly answered
+Chet was sent to the penalty box
+Chet is the current player
+They have rolled a 2
+Chet is not getting out of the penalty box
+Chet is the current player
+They have rolled a 11
+Chet is getting out of the penalty box
+Chet's new location is 1
+The category is Science
+Science Question 4
+Question was incorrectly answered
+Chet was sent to the penalty box
+Chet is the current player
+They have rolled a 2
+Chet is not getting out of the penalty box
+Chet is the current player
+They have rolled a 2
+Chet is not getting out of the penalty box
+Question was incorrectly answered
+Chet was sent to the penalty box
+Chet is the current player
+They have rolled a 1
+Chet is getting out of the penalty box
+Chet's new location is 2
+The category is Sports
+Sports Question 4
+Answer was correct!!!!
+Chet now has 2 Gold Coins.
+False
+Pat was added
+They are player number 2
+True
+Sue was added
+They are player number 3

--- a/CSharp/netcore2/TriviaTests.cs
+++ b/CSharp/netcore2/TriviaTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+using Assent;
+
+namespace Trivia
+{
+    public class TriviaTests
+    {
+        [Fact]
+        public void RefactoringTests()
+        {
+            var output = new StringBuilder();
+            Console.SetOut(new StringWriter(output));
+
+            Game aGame = new Game();
+            Console.WriteLine(aGame.IsPlayable());
+            aGame.Add("Chet");
+            aGame.Add("Pat");
+            aGame.Add("Sue");
+
+            aGame.Roll(1);
+            aGame.Roll(1);
+            aGame.Roll(1);
+            aGame.Roll(1);
+            aGame.Roll(1);
+            aGame.Roll(1);
+            aGame.Roll(1);
+            aGame.Roll(1);
+            aGame.Roll(1);
+            aGame.Roll(1);
+            aGame.Roll(1);
+            aGame.Roll(1);
+            aGame.Roll(1);
+            aGame.Roll(1);
+
+            aGame.WasCorrectlyAnswered();
+            aGame.WrongAnswer();
+
+            aGame.Roll(2);
+
+            aGame.Roll(6);
+
+            aGame.WrongAnswer();
+
+            aGame.Roll(2);
+
+            aGame.Roll(2);
+
+
+            aGame.WrongAnswer();
+
+            aGame.WasCorrectlyAnswered();
+            aGame.Roll(1);
+            aGame.WasCorrectlyAnswered();
+
+            this.Assent(output.ToString());
+        }
+    }
+}

--- a/CSharp/netcore2/trivia.csproj
+++ b/CSharp/netcore2/trivia.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Assent" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Current `CSharp` folder was missing some assets (`.sln` file) and was not properly building under mono & osx/linux.

Moved existing source files with a few updates (method names mostly) into a clean slate test project scaffold.   
Target framework is now [dotnet](https://www.microsoft.com/net) runtime (aka .NET Core) and could be used from any officially supported platform (windows, osx or linux, arm32).

Note: 
- I had to switch to using `Assent` library instead of original `ApprovalTests`, since the latter is not ported to `netcore` yet :(
- Barely checked kata content :confused: ... sorry !

