### PR TITLE
Player data clump

### DIFF
--- a/php/src/Game.php
+++ b/php/src/Game.php
@@ -69,33 +69,33 @@ class Game {
 	}
 
     public function getNameForCurrentPlayer() {
-        return $this->players[$this->currentPlayer]->getName();
+        return $this->getCurrentPlayer()->getName();
     }
 
     public function getPursesForCurrentPlayer() {
-        return $this->players[$this->currentPlayer]->getCoins();
+        return $this->getCurrentPlayer()->getCoins();
     }
 
     public function addPurseForCurrentPlayer()
     {
-        $this->players[$this->currentPlayer]->addCoin();
+        $this->getCurrentPlayer()->addCoin();
     }
 
     public function isCurrentPlayerInPenaltyBox() {
-        return $this->players[$this->currentPlayer]->isInPenaltyBox();
+        return $this->getCurrentPlayer()->isInPenaltyBox();
     }
 
     public function setCurrentPlayerInPenaltyBox() {
-        $this->players[$this->currentPlayer]->setInPenaltyBox();
+        $this->getCurrentPlayer()->setInPenaltyBox();
     }
 
     public function getPlaceForCurrentPlayer() {
-        return $this->players[$this->currentPlayer]->getPlace();
+        return $this->getCurrentPlayer()->getPlace();
     }
 
     public function movePlayerBy($roll)
     {
-        $this->players[$this->currentPlayer]->moveBy($roll);
+        $this->getCurrentPlayer()->moveBy($roll);
     }
 
 
@@ -169,14 +169,12 @@ class Game {
 						. " Gold Coins.");
 
 				$winner = $this->didPlayerWin();
-				$this->currentPlayer++;
-				if ($this->currentPlayer == count($this->players)) $this->currentPlayer = 0;
+                $this->nextPlayerTurn();
 
-				return $winner;
+                return $winner;
 			} else {
-				$this->currentPlayer++;
-				if ($this->currentPlayer == count($this->players)) $this->currentPlayer = 0;
-				return true;
+                $this->nextPlayerTurn();
+                return true;
 			}
 
 
@@ -191,10 +189,9 @@ class Game {
 					. " Gold Coins.");
 
 			$winner = $this->didPlayerWin();
-			$this->currentPlayer++;
-			if ($this->currentPlayer == count($this->players)) $this->currentPlayer = 0;
+            $this->nextPlayerTurn();
 
-			return $winner;
+            return $winner;
 		}
 	}
 
@@ -203,12 +200,25 @@ class Game {
 		echoln($this->getNameForCurrentPlayer() . " was sent to the penalty box");
 	    $this->setCurrentPlayerInPenaltyBox();
 
-		$this->currentPlayer++;
-		if ($this->currentPlayer == count($this->players)) $this->currentPlayer = 0;
-		return true;
+        $this->nextPlayerTurn();
+        return true;
 	}
 
     function didPlayerWin() {
 		return !($this->getPursesForCurrentPlayer() == 6);
 	}
+
+    public function nextPlayerTurn()
+    {
+        $this->currentPlayer++;
+        if ($this->currentPlayer == count($this->players)) $this->currentPlayer = 0;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCurrentPlayer()
+    {
+        return $this->players[$this->currentPlayer];
+    }
 }

--- a/php/src/Game.php
+++ b/php/src/Game.php
@@ -54,8 +54,8 @@ class Game {
         $player = $this->playersOnline->remove($playerNumber);
 
         echoln( $player->getName() . " leaved");
-        for($i = 0; $i < $this->playersOnline->howManyPlayers(); $i++ ) {
-            echoln($this->players[$i]->getName() . " is now number " . $i );
+        foreach($this->playersOnline->getInfo() as $playerInfo) {
+            echoln($playerInfo['name'] . " is now number " . $playerInfo['number'] );
         }
     }
 

--- a/php/src/Game.php
+++ b/php/src/Game.php
@@ -58,6 +58,9 @@ class Game {
     function remove($playerNumber) {
         $player = $this->players[$playerNumber];
         array_splice($this->players, $playerNumber, 1);
+        if ( $player === $this->mustache ) {
+            $this->mustache = $this->players[$this->currentPlayer];
+        }
 
         echoln( $player->getName() . " leaved");
         for( $i = 0; $i < $this->howManyPlayers(); $i++ ) {

--- a/php/src/Game.php
+++ b/php/src/Game.php
@@ -46,24 +46,21 @@ class Game {
 		return ($this->howManyPlayers() >= 2);
 	}
 
-    function add($playerName) {
-	   array_push($this->players, $playerName);
-	   $this->places[$this->howManyPlayers()] = 0;
-	   $this->purses[$this->howManyPlayers()] = 0;
-	   $this->inPenaltyBox[$this->howManyPlayers()] = false;
+    function add($player) {
+	    array_push($this->players,$player);
 
-	    echoln($playerName . " was added");
+	    echoln($player->getName() . " was added");
 	    echoln("They are player number " . count($this->players));
 		return true;
 	}
 
     function remove($playerNumber) {
-        $playerName = $this->players[$playerNumber];
+        $player = $this->players[$playerNumber];
         array_splice($this->players, $playerNumber, 1);
 
-        echoln( $playerName . " leaved");
+        echoln( $player->getName() . " leaved");
         for( $i = 0; $i < $this->howManyPlayers(); $i++ ) {
-            echoln($this->players[$i] . " is now number " . $i );
+            echoln($this->players[$i]->getName() . " is now number " . $i );
         }
     }
 
@@ -72,29 +69,35 @@ class Game {
 	}
 
     public function getNameForCurrentPlayer() {
-        return $this->players[$this->currentPlayer];
+        return $this->players[$this->currentPlayer]->getName();
     }
 
     public function getPursesForCurrentPlayer() {
-        return $this->purses[$this->currentPlayer];
+        return $this->players[$this->currentPlayer]->getCoins();
     }
 
     public function addPurseForCurrentPlayer()
     {
-        $this->purses[$this->currentPlayer]++;
+        $this->players[$this->currentPlayer]->addCoin();
     }
 
     public function isCurrentPlayerInPenaltyBox() {
-        return $this->inPenaltyBox[$this->currentPlayer];
+        return $this->players[$this->currentPlayer]->isInPenaltyBox();
     }
 
     public function setCurrentPlayerInPenaltyBox() {
-        $this->inPenaltyBox[$this->currentPlayer] = true;
+        $this->players[$this->currentPlayer]->setInPenaltyBox();
     }
 
     public function getPlaceForCurrentPlayer() {
-        return $this->places[$this->currentPlayer];
+        return $this->players[$this->currentPlayer]->getPlace();
     }
+
+    public function movePlayerBy($roll)
+    {
+        $this->players[$this->currentPlayer]->moveBy($roll);
+    }
+
 
     function  roll($roll) {
 		echoln($this->getNameForCurrentPlayer() . " is the current player");
@@ -105,12 +108,11 @@ class Game {
 				$this->isGettingOutOfPenaltyBox = true;
 
 				echoln($this->getNameForCurrentPlayer() . " is getting out of the penalty box");
-			$this->places[$this->currentPlayer] = $this->places[$this->currentPlayer] + $roll;
-				if ($this->places[$this->currentPlayer] > 11) $this->places[$this->currentPlayer] = $this->places[$this->currentPlayer] - 12;
+			    $this->movePlayerBy($roll);
 
 				echoln($this->getNameForCurrentPlayer()
 						. "'s new location is "
-						.$this->places[$this->currentPlayer]);
+						. $this->getPlaceForCurrentPlayer());
 				echoln("The category is " . $this->currentCategory());
 				$this->askQuestion();
 			} else {
@@ -124,13 +126,12 @@ class Game {
 
             echoln($this->getNameForCurrentPlayer()
 					. "'s new location is "
-					.$this->places[$this->currentPlayer]);
+					. $this->getPlaceForCurrentPlayer());
 			echoln("The category is " . $this->currentCategory());
 			$this->askQuestion();
 		}
 
 	}
-
 
     function  askQuestion() {
 		if ($this->currentCategory() == "Pop")
@@ -156,6 +157,7 @@ class Game {
 		return "Rock";
 	}
 
+
     function wasCorrectlyAnswered() {
 		if ($this->isCurrentPlayerInPenaltyBox()){
 			if ($this->isGettingOutOfPenaltyBox) {
@@ -163,7 +165,7 @@ class Game {
 			$this->addPurseForCurrentPlayer();
 				echoln($this->getNameForCurrentPlayer()
 						. " now has "
-						.$this->purses[$this->currentPlayer]
+						. $this->getPursesForCurrentPlayer()
 						. " Gold Coins.");
 
 				$winner = $this->didPlayerWin();
@@ -182,10 +184,10 @@ class Game {
 		} else {
 
 			echoln("Answer was corrent!!!!");
-		$this->purses[$this->currentPlayer]++;
+		    $this->addPurseForCurrentPlayer();
 			echoln($this->getNameForCurrentPlayer()
 					. " now has "
-					.$this->getPursesForCurrentPlayer()
+					. $this->getPursesForCurrentPlayer()
 					. " Gold Coins.");
 
 			$winner = $this->didPlayerWin();
@@ -196,11 +198,10 @@ class Game {
 		}
 	}
 
-
     function wrongAnswer(){
 		echoln("Question was incorrectly answered");
 		echoln($this->getNameForCurrentPlayer() . " was sent to the penalty box");
-	$this->setCurrentPlayerInPenaltyBox();
+	    $this->setCurrentPlayerInPenaltyBox();
 
 		$this->currentPlayer++;
 		if ($this->currentPlayer == count($this->players)) $this->currentPlayer = 0;
@@ -210,13 +211,4 @@ class Game {
     function didPlayerWin() {
 		return !($this->getPursesForCurrentPlayer() == 6);
 	}
-
-    /**
-     * @param $roll
-     */
-    public function movePlayerBy($roll)
-    {
-        $this->places[$this->currentPlayer] = $this->places[$this->currentPlayer] + $roll;
-        if ($this->places[$this->currentPlayer] > 11) $this->places[$this->currentPlayer] = $this->places[$this->currentPlayer] - 12;
-    }
 }

--- a/php/src/Game.php
+++ b/php/src/Game.php
@@ -17,6 +17,7 @@ class Game {
 
     var $currentPlayer = 0;
     var $isGettingOutOfPenaltyBox;
+    private $mustache;
 
     function  __construct(){
 
@@ -212,13 +213,14 @@ class Game {
     {
         $this->currentPlayer++;
         if ($this->currentPlayer == count($this->players)) $this->currentPlayer = 0;
+        $this->mustache = $this->players[$this->currentPlayer];
     }
 
-    /**
-     * @return mixed
-     */
     public function getCurrentPlayer()
     {
-        return $this->players[$this->currentPlayer];
+        if ( ! isset( $this->mustache ) ) {
+            $this->mustache = $this->players[0];
+        }
+        return $this->mustache;
     }
 }

--- a/php/src/Game.php
+++ b/php/src/Game.php
@@ -57,6 +57,16 @@ class Game {
 		return true;
 	}
 
+	function remove($playerNumber) {
+        $playerName = $this->players[$playerNumber];
+        array_splice($this->players, $playerNumber, 1);
+
+        echoln( $playerName . " leaved");
+        for( $i = 0; $i < $this->howManyPlayers(); $i++ ) {
+            echoln($this->players[$i] . " is now number " . $i );
+        }
+    }
+
 	function howManyPlayers() {
 		return count($this->players);
 	}

--- a/php/src/Game.php
+++ b/php/src/Game.php
@@ -6,10 +6,6 @@ function echoln($string) {
 
 class Game {
     private $playersOnline;
-    var $places;
-    var $purses ;
-    var $inPenaltyBox ;
-
     var $popQuestions;
     var $scienceQuestions;
     var $sportsQuestions;
@@ -20,7 +16,7 @@ class Game {
     function  __construct(){
 
         $this->playersOnline = new PlayersList();
-   	$this->players = array();
+   	    $this->players = array();
         $this->places = array(0);
         $this->purses  = array(0);
         $this->inPenaltyBox  = array(0);
@@ -63,65 +59,34 @@ class Game {
         }
     }
 
-    public function getNameForCurrentPlayer() {
-        return $this->playersOnline->getCurrentPlayer($this)->getName();
-    }
-
-    public function getPursesForCurrentPlayer() {
-        return $this->playersOnline->getCurrentPlayer($this)->getCoins();
-    }
-
-    public function addPurseForCurrentPlayer()
-    {
-        $this->playersOnline->getCurrentPlayer($this)->addCoin();
-    }
-
-    public function isCurrentPlayerInPenaltyBox() {
-        return $this->playersOnline->getCurrentPlayer($this)->isInPenaltyBox();
-    }
-
-    public function setCurrentPlayerInPenaltyBox() {
-        $this->playersOnline->getCurrentPlayer($this)->setInPenaltyBox();
-    }
-
-    public function getPlaceForCurrentPlayer() {
-        return $this->playersOnline->getCurrentPlayer($this)->getPlace();
-    }
-
-    public function movePlayerBy($roll)
-    {
-        $this->playersOnline->getCurrentPlayer($this)->moveBy($roll);
-    }
-
-
     function  roll($roll) {
-		echoln($this->getNameForCurrentPlayer() . " is the current player");
+		echoln($this->playersOnline->getCurrentPlayer()->getName() . " is the current player");
 		echoln("They have rolled a " . $roll);
 
-		if ($this->isCurrentPlayerInPenaltyBox()) {
+		if ($this->playersOnline->getCurrentPlayer()->isInPenaltyBox()) {
 			if ($roll % 2 != 0) {
 				$this->isGettingOutOfPenaltyBox = true;
 
-				echoln($this->getNameForCurrentPlayer() . " is getting out of the penalty box");
-			    $this->movePlayerBy($roll);
+				echoln($this->playersOnline->getCurrentPlayer()->getName() . " is getting out of the penalty box");
+			    $this->playersOnline->getCurrentPlayer()->moveBy($roll);
 
-				echoln($this->getNameForCurrentPlayer()
+				echoln($this->playersOnline->getCurrentPlayer()->getName()
 						. "'s new location is "
-						. $this->getPlaceForCurrentPlayer());
+						. $this->playersOnline->getCurrentPlayer()->getPlace());
 				echoln("The category is " . $this->currentCategory());
 				$this->askQuestion();
 			} else {
-				echoln($this->getNameForCurrentPlayer() . " is not getting out of the penalty box");
+				echoln($this->playersOnline->getCurrentPlayer()->getName() . " is not getting out of the penalty box");
 				$this->isGettingOutOfPenaltyBox = false;
 				}
 
 		} else {
 
-            $this->movePlayerBy($roll);
+            $this->playersOnline->getCurrentPlayer()->moveBy($roll);
 
-            echoln($this->getNameForCurrentPlayer()
+            echoln($this->playersOnline->getCurrentPlayer()->getName()
 					. "'s new location is "
-					. $this->getPlaceForCurrentPlayer());
+					. $this->playersOnline->getCurrentPlayer()->getPlace());
 			echoln("The category is " . $this->currentCategory());
 			$this->askQuestion();
 		}
@@ -140,35 +105,35 @@ class Game {
 	}
 
     function currentCategory() {
-		if ($this->getPlaceForCurrentPlayer() == 0) return "Pop";
-		if ($this->getPlaceForCurrentPlayer() == 4) return "Pop";
-		if ($this->getPlaceForCurrentPlayer() == 8) return "Pop";
-		if ($this->getPlaceForCurrentPlayer() == 1) return "Science";
-		if ($this->getPlaceForCurrentPlayer() == 5) return "Science";
-		if ($this->getPlaceForCurrentPlayer() == 9) return "Science";
-		if ($this->getPlaceForCurrentPlayer() == 2) return "Sports";
-		if ($this->getPlaceForCurrentPlayer() == 6) return "Sports";
-		if ($this->getPlaceForCurrentPlayer() == 10) return "Sports";
+		if ($this->playersOnline->getCurrentPlayer()->getPlace() == 0) return "Pop";
+		if ($this->playersOnline->getCurrentPlayer()->getPlace() == 4) return "Pop";
+		if ($this->playersOnline->getCurrentPlayer()->getPlace() == 8) return "Pop";
+		if ($this->playersOnline->getCurrentPlayer()->getPlace() == 1) return "Science";
+		if ($this->playersOnline->getCurrentPlayer()->getPlace() == 5) return "Science";
+		if ($this->playersOnline->getCurrentPlayer()->getPlace() == 9) return "Science";
+		if ($this->playersOnline->getCurrentPlayer()->getPlace() == 2) return "Sports";
+		if ($this->playersOnline->getCurrentPlayer()->getPlace() == 6) return "Sports";
+		if ($this->playersOnline->getCurrentPlayer()->getPlace() == 10) return "Sports";
 		return "Rock";
 	}
 
 
     function wasCorrectlyAnswered() {
-		if ($this->isCurrentPlayerInPenaltyBox()){
+		if ($this->playersOnline->getCurrentPlayer()->isInPenaltyBox()){
 			if ($this->isGettingOutOfPenaltyBox) {
 				echoln("Answer was correct!!!!");
-			$this->addPurseForCurrentPlayer();
-				echoln($this->getNameForCurrentPlayer()
+			$this->playersOnline->getCurrentPlayer()->addCoin();
+				echoln($this->playersOnline->getCurrentPlayer()->getName()
 						. " now has "
-						. $this->getPursesForCurrentPlayer()
+						. $this->playersOnline->getCurrentPlayer()->getCoins()
 						. " Gold Coins.");
 
 				$winner = $this->didPlayerWin();
-                $this->playersOnline->nextPlayerTurn($this);
+                $this->playersOnline->nextPlayerTurn();
 
                 return $winner;
 			} else {
-                $this->playersOnline->nextPlayerTurn($this);
+                $this->playersOnline->nextPlayerTurn();
                 return true;
 			}
 
@@ -177,14 +142,14 @@ class Game {
 		} else {
 
 			echoln("Answer was corrent!!!!");
-		    $this->addPurseForCurrentPlayer();
-			echoln($this->getNameForCurrentPlayer()
+		    $this->playersOnline->getCurrentPlayer()->addCoin();
+			echoln($this->playersOnline->getCurrentPlayer()->getName()
 					. " now has "
-					. $this->getPursesForCurrentPlayer()
+					. $this->playersOnline->getCurrentPlayer()->getCoins()
 					. " Gold Coins.");
 
 			$winner = $this->didPlayerWin();
-            $this->playersOnline->nextPlayerTurn($this);
+            $this->playersOnline->nextPlayerTurn();
 
             return $winner;
 		}
@@ -192,15 +157,15 @@ class Game {
 
     function wrongAnswer(){
 		echoln("Question was incorrectly answered");
-		echoln($this->getNameForCurrentPlayer() . " was sent to the penalty box");
-	    $this->setCurrentPlayerInPenaltyBox();
+		echoln($this->playersOnline->getCurrentPlayer()->getName() . " was sent to the penalty box");
+	    $this->playersOnline->getCurrentPlayer()->setInPenaltyBox();
 
-        $this->playersOnline->nextPlayerTurn($this);
+        $this->playersOnline->nextPlayerTurn();
         return true;
 	}
 
     function didPlayerWin() {
-		return !($this->getPursesForCurrentPlayer() == 6);
+		return !($this->playersOnline->getCurrentPlayer()->getCoins() == 6);
 	}
 
 }

--- a/php/src/Game.php
+++ b/php/src/Game.php
@@ -5,7 +5,7 @@ function echoln($string) {
 }
 
 class Game {
-    var $players;
+    private $playersOnline;
     var $places;
     var $purses ;
     var $inPenaltyBox ;
@@ -15,12 +15,11 @@ class Game {
     var $sportsQuestions;
     var $rockQuestions;
 
-    var $currentPlayer = 0;
     var $isGettingOutOfPenaltyBox;
-    private $mustache;
 
     function  __construct(){
 
+        $this->playersOnline = new PlayersList();
    	$this->players = array();
         $this->places = array(0);
         $this->purses  = array(0);
@@ -44,62 +43,54 @@ class Game {
 	}
 
     function isPlayable() {
-		return ($this->howManyPlayers() >= 2);
+		return ($this->playersOnline->howManyPlayers() >= 2);
 	}
 
-    function add($player) {
-	    array_push($this->players,$player);
+    function addPlayer($player) {
+        $this->playersOnline->add($player);
 
-	    echoln($player->getName() . " was added");
-	    echoln("They are player number " . count($this->players));
+        echoln($player->getName() . " was added");
+	    echoln("They are player number " . $this->playersOnline->howManyPlayers());
 		return true;
 	}
 
-    function remove($playerNumber) {
-        $player = $this->players[$playerNumber];
-        array_splice($this->players, $playerNumber, 1);
-        if ( $player === $this->mustache ) {
-            $this->mustache = $this->players[$this->currentPlayer];
-        }
+    function removePlayer($playerNumber) {
+        $player = $this->playersOnline->remove($playerNumber);
 
         echoln( $player->getName() . " leaved");
-        for( $i = 0; $i < $this->howManyPlayers(); $i++ ) {
+        for($i = 0; $i < $this->playersOnline->howManyPlayers(); $i++ ) {
             echoln($this->players[$i]->getName() . " is now number " . $i );
         }
     }
 
-    function howManyPlayers() {
-		return count($this->players);
-	}
-
     public function getNameForCurrentPlayer() {
-        return $this->getCurrentPlayer()->getName();
+        return $this->playersOnline->getCurrentPlayer($this)->getName();
     }
 
     public function getPursesForCurrentPlayer() {
-        return $this->getCurrentPlayer()->getCoins();
+        return $this->playersOnline->getCurrentPlayer($this)->getCoins();
     }
 
     public function addPurseForCurrentPlayer()
     {
-        $this->getCurrentPlayer()->addCoin();
+        $this->playersOnline->getCurrentPlayer($this)->addCoin();
     }
 
     public function isCurrentPlayerInPenaltyBox() {
-        return $this->getCurrentPlayer()->isInPenaltyBox();
+        return $this->playersOnline->getCurrentPlayer($this)->isInPenaltyBox();
     }
 
     public function setCurrentPlayerInPenaltyBox() {
-        $this->getCurrentPlayer()->setInPenaltyBox();
+        $this->playersOnline->getCurrentPlayer($this)->setInPenaltyBox();
     }
 
     public function getPlaceForCurrentPlayer() {
-        return $this->getCurrentPlayer()->getPlace();
+        return $this->playersOnline->getCurrentPlayer($this)->getPlace();
     }
 
     public function movePlayerBy($roll)
     {
-        $this->getCurrentPlayer()->moveBy($roll);
+        $this->playersOnline->getCurrentPlayer($this)->moveBy($roll);
     }
 
 
@@ -173,11 +164,11 @@ class Game {
 						. " Gold Coins.");
 
 				$winner = $this->didPlayerWin();
-                $this->nextPlayerTurn();
+                $this->playersOnline->nextPlayerTurn($this);
 
                 return $winner;
 			} else {
-                $this->nextPlayerTurn();
+                $this->playersOnline->nextPlayerTurn($this);
                 return true;
 			}
 
@@ -193,7 +184,7 @@ class Game {
 					. " Gold Coins.");
 
 			$winner = $this->didPlayerWin();
-            $this->nextPlayerTurn();
+            $this->playersOnline->nextPlayerTurn($this);
 
             return $winner;
 		}
@@ -204,7 +195,7 @@ class Game {
 		echoln($this->getNameForCurrentPlayer() . " was sent to the penalty box");
 	    $this->setCurrentPlayerInPenaltyBox();
 
-        $this->nextPlayerTurn();
+        $this->playersOnline->nextPlayerTurn($this);
         return true;
 	}
 
@@ -212,18 +203,4 @@ class Game {
 		return !($this->getPursesForCurrentPlayer() == 6);
 	}
 
-    public function nextPlayerTurn()
-    {
-        $this->currentPlayer++;
-        if ($this->currentPlayer == count($this->players)) $this->currentPlayer = 0;
-        $this->mustache = $this->players[$this->currentPlayer];
-    }
-
-    public function getCurrentPlayer()
-    {
-        if ( ! isset( $this->mustache ) ) {
-            $this->mustache = $this->players[0];
-        }
-        return $this->mustache;
-    }
 }

--- a/php/src/Game.php
+++ b/php/src/Game.php
@@ -38,15 +38,15 @@ class Game {
     	}
     }
 
-	function createRockQuestion($index){
+    function createRockQuestion($index){
 		return "Rock Question " . $index;
 	}
 
-	function isPlayable() {
+    function isPlayable() {
 		return ($this->howManyPlayers() >= 2);
 	}
 
-	function add($playerName) {
+    function add($playerName) {
 	   array_push($this->players, $playerName);
 	   $this->places[$this->howManyPlayers()] = 0;
 	   $this->purses[$this->howManyPlayers()] = 0;
@@ -57,7 +57,7 @@ class Game {
 		return true;
 	}
 
-	function remove($playerNumber) {
+    function remove($playerNumber) {
         $playerName = $this->players[$playerNumber];
         array_splice($this->players, $playerNumber, 1);
 
@@ -67,38 +67,62 @@ class Game {
         }
     }
 
-	function howManyPlayers() {
+    function howManyPlayers() {
 		return count($this->players);
 	}
 
-	function  roll($roll) {
-		echoln($this->players[$this->currentPlayer] . " is the current player");
+    public function getNameForCurrentPlayer() {
+        return $this->players[$this->currentPlayer];
+    }
+
+    public function getPursesForCurrentPlayer() {
+        return $this->purses[$this->currentPlayer];
+    }
+
+    public function addPurseForCurrentPlayer()
+    {
+        $this->purses[$this->currentPlayer]++;
+    }
+
+    public function isCurrentPlayerInPenaltyBox() {
+        return $this->inPenaltyBox[$this->currentPlayer];
+    }
+
+    public function setCurrentPlayerInPenaltyBox() {
+        $this->inPenaltyBox[$this->currentPlayer] = true;
+    }
+
+    public function getPlaceForCurrentPlayer() {
+        return $this->places[$this->currentPlayer];
+    }
+
+    function  roll($roll) {
+		echoln($this->getNameForCurrentPlayer() . " is the current player");
 		echoln("They have rolled a " . $roll);
 
-		if ($this->inPenaltyBox[$this->currentPlayer]) {
+		if ($this->isCurrentPlayerInPenaltyBox()) {
 			if ($roll % 2 != 0) {
 				$this->isGettingOutOfPenaltyBox = true;
 
-				echoln($this->players[$this->currentPlayer] . " is getting out of the penalty box");
+				echoln($this->getNameForCurrentPlayer() . " is getting out of the penalty box");
 			$this->places[$this->currentPlayer] = $this->places[$this->currentPlayer] + $roll;
 				if ($this->places[$this->currentPlayer] > 11) $this->places[$this->currentPlayer] = $this->places[$this->currentPlayer] - 12;
 
-				echoln($this->players[$this->currentPlayer]
+				echoln($this->getNameForCurrentPlayer()
 						. "'s new location is "
 						.$this->places[$this->currentPlayer]);
 				echoln("The category is " . $this->currentCategory());
 				$this->askQuestion();
 			} else {
-				echoln($this->players[$this->currentPlayer] . " is not getting out of the penalty box");
+				echoln($this->getNameForCurrentPlayer() . " is not getting out of the penalty box");
 				$this->isGettingOutOfPenaltyBox = false;
 				}
 
 		} else {
 
-		$this->places[$this->currentPlayer] = $this->places[$this->currentPlayer] + $roll;
-			if ($this->places[$this->currentPlayer] > 11) $this->places[$this->currentPlayer] = $this->places[$this->currentPlayer] - 12;
+            $this->movePlayerBy($roll);
 
-			echoln($this->players[$this->currentPlayer]
+            echoln($this->getNameForCurrentPlayer()
 					. "'s new location is "
 					.$this->places[$this->currentPlayer]);
 			echoln("The category is " . $this->currentCategory());
@@ -107,7 +131,8 @@ class Game {
 
 	}
 
-	function  askQuestion() {
+
+    function  askQuestion() {
 		if ($this->currentCategory() == "Pop")
 			echoln(array_shift($this->popQuestions));
 		if ($this->currentCategory() == "Science")
@@ -118,26 +143,25 @@ class Game {
 			echoln(array_shift($this->rockQuestions));
 	}
 
-
-	function currentCategory() {
-		if ($this->places[$this->currentPlayer] == 0) return "Pop";
-		if ($this->places[$this->currentPlayer] == 4) return "Pop";
-		if ($this->places[$this->currentPlayer] == 8) return "Pop";
-		if ($this->places[$this->currentPlayer] == 1) return "Science";
-		if ($this->places[$this->currentPlayer] == 5) return "Science";
-		if ($this->places[$this->currentPlayer] == 9) return "Science";
-		if ($this->places[$this->currentPlayer] == 2) return "Sports";
-		if ($this->places[$this->currentPlayer] == 6) return "Sports";
-		if ($this->places[$this->currentPlayer] == 10) return "Sports";
+    function currentCategory() {
+		if ($this->getPlaceForCurrentPlayer() == 0) return "Pop";
+		if ($this->getPlaceForCurrentPlayer() == 4) return "Pop";
+		if ($this->getPlaceForCurrentPlayer() == 8) return "Pop";
+		if ($this->getPlaceForCurrentPlayer() == 1) return "Science";
+		if ($this->getPlaceForCurrentPlayer() == 5) return "Science";
+		if ($this->getPlaceForCurrentPlayer() == 9) return "Science";
+		if ($this->getPlaceForCurrentPlayer() == 2) return "Sports";
+		if ($this->getPlaceForCurrentPlayer() == 6) return "Sports";
+		if ($this->getPlaceForCurrentPlayer() == 10) return "Sports";
 		return "Rock";
 	}
 
-	function wasCorrectlyAnswered() {
-		if ($this->inPenaltyBox[$this->currentPlayer]){
+    function wasCorrectlyAnswered() {
+		if ($this->isCurrentPlayerInPenaltyBox()){
 			if ($this->isGettingOutOfPenaltyBox) {
 				echoln("Answer was correct!!!!");
-			$this->purses[$this->currentPlayer]++;
-				echoln($this->players[$this->currentPlayer]
+			$this->addPurseForCurrentPlayer();
+				echoln($this->getNameForCurrentPlayer()
 						. " now has "
 						.$this->purses[$this->currentPlayer]
 						. " Gold Coins.");
@@ -159,9 +183,9 @@ class Game {
 
 			echoln("Answer was corrent!!!!");
 		$this->purses[$this->currentPlayer]++;
-			echoln($this->players[$this->currentPlayer]
+			echoln($this->getNameForCurrentPlayer()
 					. " now has "
-					.$this->purses[$this->currentPlayer]
+					.$this->getPursesForCurrentPlayer()
 					. " Gold Coins.");
 
 			$winner = $this->didPlayerWin();
@@ -172,18 +196,27 @@ class Game {
 		}
 	}
 
-	function wrongAnswer(){
+
+    function wrongAnswer(){
 		echoln("Question was incorrectly answered");
-		echoln($this->players[$this->currentPlayer] . " was sent to the penalty box");
-	$this->inPenaltyBox[$this->currentPlayer] = true;
+		echoln($this->getNameForCurrentPlayer() . " was sent to the penalty box");
+	$this->setCurrentPlayerInPenaltyBox();
 
 		$this->currentPlayer++;
 		if ($this->currentPlayer == count($this->players)) $this->currentPlayer = 0;
 		return true;
 	}
 
-
-	function didPlayerWin() {
-		return !($this->purses[$this->currentPlayer] == 6);
+    function didPlayerWin() {
+		return !($this->getPursesForCurrentPlayer() == 6);
 	}
+
+    /**
+     * @param $roll
+     */
+    public function movePlayerBy($roll)
+    {
+        $this->places[$this->currentPlayer] = $this->places[$this->currentPlayer] + $roll;
+        if ($this->places[$this->currentPlayer] > 11) $this->places[$this->currentPlayer] = $this->places[$this->currentPlayer] - 12;
+    }
 }

--- a/php/src/GameRunner.php
+++ b/php/src/GameRunner.php
@@ -15,17 +15,34 @@ class GameRunner {
 
         do {
 
-            $aGame->roll(rand(0,5) + 1);
-
-            if (rand(0,9) == 7) {
-                $notAWinner = $aGame->wrongAnswer();
-            } else {
-                $notAWinner = $aGame->wasCorrectlyAnswered();
-            }
-
+            $notAWinner = self::runRound($aGame);
 
 
         } while ($notAWinner);
+    }
+
+    /**
+     * @param Game $aGame
+     * @return bool
+     */
+    public static function runRound(Game $aGame)
+    {
+        $aGame->roll(rand(0, 5) + 1);
+
+        if (rand(0, 9) == 7) {
+            $notAWinner = $aGame->wrongAnswer();
+        } else {
+            $notAWinner = $aGame->wasCorrectlyAnswered();
+        }
+        return $notAWinner;
+    }
+
+    public static function runRounds( $aGame, $number ) {
+        $notAWinner = true;
+        for ($i=0; $i < $number; $i++) {
+            $notAWinner = ( $notAWinner && self::runRound($aGame) );
+        }
+        return $notAWinner;
     }
 }
 

--- a/php/src/GameRunner.php
+++ b/php/src/GameRunner.php
@@ -8,9 +8,9 @@ class GameRunner {
 
         $aGame = new Game();
 
-        $aGame->add("Chet");
-        $aGame->add("Pat");
-        $aGame->add("Sue");
+        $aGame->add(new Player("Chet"));
+        $aGame->add(new Player("Pat"));
+        $aGame->add(new Player("Sue"));
 
 
         do {

--- a/php/src/GameRunner.php
+++ b/php/src/GameRunner.php
@@ -8,9 +8,9 @@ class GameRunner {
 
         $aGame = new Game();
 
-        $aGame->add(new Player("Chet"));
-        $aGame->add(new Player("Pat"));
-        $aGame->add(new Player("Sue"));
+        $aGame->addPlayer(new Player("Chet"));
+        $aGame->addPlayer(new Player("Pat"));
+        $aGame->addPlayer(new Player("Sue"));
 
 
         do {

--- a/php/src/Player.php
+++ b/php/src/Player.php
@@ -1,0 +1,57 @@
+<?php
+
+
+namespace Game;
+
+
+class Player
+{
+    private $name;
+    private $place = 0;
+    private $coins = 0;
+    private $inPenaltyBox = false;
+
+    /**
+     * Player constructor.
+     * @param $playerName
+     */
+    public function __construct($playerName)
+    {
+        $this->name = $playerName;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getPlace()
+    {
+        return $this->place;
+    }
+
+    public function moveBy($number) {
+        $this->place = $this->place + $number;
+        if ($this->place > 11) $this->place = $this->place - 12;
+    }
+
+    public function getCoins()
+    {
+        return $this->coins;
+    }
+
+    public function addCoin() {
+        $this->coins++;
+    }
+
+    public function isInPenaltyBox() {
+        return $this->inPenaltyBox;
+    }
+
+    public function setInPenaltyBox() {
+        $this->inPenaltyBox = true;
+    }
+
+
+
+}

--- a/php/src/PlayerInfoIterator.php
+++ b/php/src/PlayerInfoIterator.php
@@ -1,0 +1,49 @@
+<?php
+
+
+namespace Game;
+
+
+use Iterator;
+
+class PlayerInfoIterator implements Iterator
+{
+
+    private $playersInfo = array();
+    private $currentPlayerNumber = 0;
+    public function __construct($players) {
+        for($i = 0; $i < count( $players ); $i++) {
+            $this->playersInfo[] = [
+                'name'   => $players[$i]->getName(),
+                'number' => $i
+            ];
+        }
+    }
+
+    public function current()
+    {
+        return $this->playersInfo[$this->currentPlayerNumber];
+    }
+
+    public function next()
+    {
+        return $this->currentPlayerNumber++;
+    }
+
+    public function key()
+    {
+        return $this->currentPlayerNumber;
+    }
+
+    public function valid()
+    {
+        return $this->currentPlayerNumber < count($this->playersInfo);
+    }
+
+    public function rewind()
+    {
+        $this->currentPlayerNumber = 0;
+    }
+
+
+}

--- a/php/src/PlayersList.php
+++ b/php/src/PlayersList.php
@@ -1,0 +1,50 @@
+<?php
+
+
+namespace Game;
+
+class PlayersList {
+
+    private $players = array();
+    private $currentPlayer;
+    private $currentPlayerNumber = 0;
+
+    public function __construct( ...$players ) {
+        $this->players = $players;
+    }
+
+    function howManyPlayers()
+    {
+        return count($this->players);
+    }
+
+    public function add($player)
+    {
+        array_push($this->players, $player);
+    }
+
+    public function remove($playerNumber)
+    {
+        $player = $this->players[$playerNumber];
+        array_splice($this->players, $playerNumber, 1);
+        if ($player === $this->currentPlayer) {
+            $this->currentPlayer = $this->players[$this->currentPlayerNumber];
+        }
+        return $player;
+    }
+
+    public function getCurrentPlayer()
+    {
+        if (!isset($this->currentPlayer)) {
+            $this->currentPlayer = $this->players[$this->currentPlayerNumber];
+        }
+        return $this->currentPlayer;
+    }
+
+    public function nextPlayerTurn()
+    {
+        $this->currentPlayerNumber++;
+        if ($this->currentPlayerNumber == count($this->players)) $this->currentPlayerNumber = 0;
+        $this->currentPlayer = $this->players[$this->currentPlayerNumber];
+    }
+}

--- a/php/src/PlayersList.php
+++ b/php/src/PlayersList.php
@@ -47,4 +47,8 @@ class PlayersList {
         if ($this->currentPlayerNumber == count($this->players)) $this->currentPlayerNumber = 0;
         $this->currentPlayer = $this->players[$this->currentPlayerNumber];
     }
+
+    public function getInfo() {
+        return new PlayerInfoIterator($this->players);
+    }
 }

--- a/php/test/PlayersListTest.php
+++ b/php/test/PlayersListTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Game;
+
+
+use PHPUnit\Framework\TestCase;
+
+class PlayersListTest extends TestCase
+{
+    public function testCorrectNumberOfPlayersWhenPlayersAdded() {
+        $playersList = new PlayersList(
+            new Player( 'Kristof' ),
+            new Player( 'Julio' ),
+            new Player( 'Soraya' )
+        );
+
+        $this->assertEquals( 3, $playersList->howManyPlayers());
+
+        return $playersList;
+    }
+
+    /**
+     * @depends testCorrectNumberOfPlayersWhenPlayersAdded
+     *
+     * @param PlayersList
+     */
+    public function testCorrectNumberOfPlayersWhenPlayerRemoved($playersList)
+    {
+        $playersList->remove(1);
+
+        $this->assertEquals(2, $playersList->howManyPlayers());
+    }
+
+    public function setThreePlayersList()
+    {
+        $damien = new Player('Damien');
+        $aicha = new Player('Aïcha');
+        $stephanie = new Player('Stéphanie');
+        $playersList = new PlayersList($damien, $aicha, $stephanie);
+        return array($damien, $aicha, $stephanie, $playersList);
+    }
+
+    public function testKeepCurrentPlayerWhenPlayerLeaves() {
+        list($damien, $aicha, $stephanie, $playersList) = $this->setThreePlayersList();
+
+        $playersList->nextPlayerTurn();
+
+        $playersList->remove(0);
+
+        $this->assertEquals( $aicha, $playersList->getCurrentPlayer());
+    }
+
+    public function testGetNextPlayerWhenCurrentPlayerLeaves() {
+        list($damien, $aicha, $stephanie, $playersList) = $this->setThreePlayersList();
+
+        $playersList->nextPlayerTurn();
+
+        $playersList->remove(1);
+
+        $this->assertEquals( $stephanie, $playersList->getCurrentPlayer());
+    }
+}

--- a/php/test/Test.php
+++ b/php/test/Test.php
@@ -17,7 +17,7 @@ class GameTest extends TestCase
         $actual = ob_get_contents();
         ob_end_clean();
 
-        $expected = file_get_contents('approved.txt');
+        $expected = file_get_contents(__DIR__ . '/approved.txt');
         $this->assertEquals($expected, $actual);
 
     }

--- a/php/test/Test.php
+++ b/php/test/Test.php
@@ -59,7 +59,21 @@ class GameTest extends TestCase
 
         $game->remove(0);
 
-        $this->assertEquals( 'Aïcha', $game->getCurrentPlayer()->getName() );
+        $this->assertEquals( 'Aïcha', $game->getNameForCurrentPlayer());
+    }
+
+    public function testGetNextPlayerWhenCurrentPlayerLeaves() {
+        $game = $this->setGameForPlayers(
+            new Player('Camilla'),
+            new Player('Ludwig'),
+            new Player('Amine')
+        );
+
+        GameRunner::runRound($game);
+
+        $game->remove(1);
+
+        $this->assertEquals( 'Amine', $game->getNameForCurrentPlayer());
     }
 
     public function playerDataTurnTwelve() {

--- a/php/test/Test.php
+++ b/php/test/Test.php
@@ -1,5 +1,6 @@
 <?php
 
+use Game\Game;
 use Game\GameRunner;
 use PHPUnit\Framework\TestCase;
 
@@ -20,5 +21,27 @@ class GameTest extends TestCase
         $expected = file_get_contents(__DIR__ . '/approved.txt');
         $this->assertEquals($expected, $actual);
 
+    }
+
+    public function testCorrectNumberOfPlayersWhenPlayersAdded() {
+        $game = new Game();
+        $game->add('Kristof');
+        $game->add('Julio');
+        $game->add('Soraya');
+
+        $this->assertEquals( 3, $game->howManyPlayers());
+
+        return $game;
+    }
+
+    /**
+     * @depends testCorrectNumberOfPlayersWhenPlayersAdded
+     *
+     * @param Game $game
+     */
+    public function testCorrectNumberOfPlayersWhenPlayerRemoved($game) {
+        $game->remove(1);
+
+        $this->assertEquals( 2, $game->howManyPlayers());
     }
 }

--- a/php/test/Test.php
+++ b/php/test/Test.php
@@ -25,67 +25,17 @@ class GameTest extends TestCase
 
     }
 
-    public function playerDataTurnTwelve() {
-        return [
-            'coins' => [
-                'getCoins',
-                [
-                    'Katrin' => 4,
-                    'Constantine' => 4
-                ]
-            ],
-            'place' => [
-                'getPlace',
-                [
-                    'Katrin' => 0,
-                    'Constantine' => 8
-                ]
-            ],
-            'inPenaltyBox' => [
-                'isInPenaltyBox',
-                [
-                    'Katrin' => false,
-                    'Constantine' => false
-                ]
-            ]
-        ];
-    }
-
-    /**
-     * @dataProvider playerDataTurnTwelve
-     * @param string $getter
-     * @param array  $expectedValueFor
-     */
-    public function testPlayersKeepDataWhenOtherPlayerLeaves( $getter, $expectedValueFor ) {
-        $katrin = new Player('Katrin');
-        $seraphin = new Player('Seraphin');
-        $constantine = new Player('Constantine');
-        $game = $this->setGameForPlayers($katrin, $seraphin, $constantine );
-        $this->runRoundsDeterministically($game);
-
-        $game->removePlayer(1);
-
-        $this->assertEquals( $expectedValueFor['Katrin'], $katrin->$getter() );
-        $this->assertEquals( $expectedValueFor['Constantine'], $constantine->$getter() );
-    }
-
-    public function setGameForPlayers( ...$players )
-    {
+    public function testDisplayCorrectPlayersNumbersWhenPlayersLeave() {
         $game = new Game();
+        $game->addPlayer( new Player('Etienne') );
+        $game->addPlayer(new Player('Esmeralda'));
+        $game->addPlayer(new Player('Bigsby'));
 
-        foreach( $players as $player ) {
-            $game->addPlayer($player);
-        };
+        ob_flush();
+        ob_start();
+        $game->removePlayer(1);
+        $output = ob_end_clean();
 
-        return $game;
-    }
-
-    /**
-     * @param Game $game
-     */
-    public function runRoundsDeterministically(Game $game)
-    {
-        srand(123455);
-        GameRunner::runRounds($game, 12);
+        $this->assertEquals( '', $output );
     }
 }

--- a/php/test/Test.php
+++ b/php/test/Test.php
@@ -48,6 +48,20 @@ class GameTest extends TestCase
         $this->assertEquals(2, $game->howManyPlayers());
     }
 
+    public function testKeepCurrentPlayerWhenPlayerLeaves() {
+        $game = $this->setGameForPlayers(
+            new Player('Damien'),
+            new Player('Aïcha'),
+            new Player('Stéphanie')
+        );
+
+        GameRunner::runRound($game);
+
+        $game->remove(0);
+
+        $this->assertEquals( 'Aïcha', $game->players[$game->currentPlayer]->getName() );
+    }
+
     public function playerDataTurnTwelve() {
         return [
             'coins' => [

--- a/php/test/Test.php
+++ b/php/test/Test.php
@@ -34,8 +34,11 @@ class GameTest extends TestCase
         ob_flush();
         ob_start();
         $game->removePlayer(1);
-        $output = ob_end_clean();
+        $output = ob_get_clean();
 
-        $this->assertEquals( '', $output );
+        $this->assertEquals( 'Esmeralda leaved
+Etienne is now number 0
+Bigsby is now number 1
+', $output );
     }
 }

--- a/php/test/Test.php
+++ b/php/test/Test.php
@@ -59,7 +59,7 @@ class GameTest extends TestCase
 
         $game->remove(0);
 
-        $this->assertEquals( 'Aïcha', $game->players[$game->currentPlayer]->getName() );
+        $this->assertEquals( 'Aïcha', $game->getCurrentPlayer()->getName() );
     }
 
     public function playerDataTurnTwelve() {

--- a/php/test/Test.php
+++ b/php/test/Test.php
@@ -3,6 +3,7 @@
 use Game\Game;
 use Game\GameRunner;
 use Game\Player;
+use Game\PlayersList;
 use PHPUnit\Framework\TestCase;
 
 class GameTest extends TestCase
@@ -22,58 +23,6 @@ class GameTest extends TestCase
         $expected = file_get_contents(__DIR__ . '/approved.txt');
         $this->assertEquals($expected, $actual);
 
-    }
-
-    public function testCorrectNumberOfPlayersWhenPlayersAdded() {
-        $game = $this->setGameForPlayers(
-            new Player( 'Kristof' ),
-            new Player( 'Julio' ),
-            new Player( 'Soraya' )
-        );
-
-        $this->assertEquals( 3, $game->howManyPlayers());
-
-        return $game;
-    }
-
-    /**
-     * @depends testCorrectNumberOfPlayersWhenPlayersAdded
-     *
-     * @param Game $game
-     */
-    public function testCorrectNumberOfPlayersWhenPlayerRemoved($game)
-    {
-        $game->remove(1);
-
-        $this->assertEquals(2, $game->howManyPlayers());
-    }
-
-    public function testKeepCurrentPlayerWhenPlayerLeaves() {
-        $game = $this->setGameForPlayers(
-            new Player('Damien'),
-            new Player('Aïcha'),
-            new Player('Stéphanie')
-        );
-
-        GameRunner::runRound($game);
-
-        $game->remove(0);
-
-        $this->assertEquals( 'Aïcha', $game->getNameForCurrentPlayer());
-    }
-
-    public function testGetNextPlayerWhenCurrentPlayerLeaves() {
-        $game = $this->setGameForPlayers(
-            new Player('Camilla'),
-            new Player('Ludwig'),
-            new Player('Amine')
-        );
-
-        GameRunner::runRound($game);
-
-        $game->remove(1);
-
-        $this->assertEquals( 'Amine', $game->getNameForCurrentPlayer());
     }
 
     public function playerDataTurnTwelve() {
@@ -114,7 +63,7 @@ class GameTest extends TestCase
         $game = $this->setGameForPlayers($katrin, $seraphin, $constantine );
         $this->runRoundsDeterministically($game);
 
-        $game->remove(1);
+        $game->removePlayer(1);
 
         $this->assertEquals( $expectedValueFor['Katrin'], $katrin->$getter() );
         $this->assertEquals( $expectedValueFor['Constantine'], $constantine->$getter() );
@@ -125,7 +74,7 @@ class GameTest extends TestCase
         $game = new Game();
 
         foreach( $players as $player ) {
-            $game->add($player);
+            $game->addPlayer($player);
         };
 
         return $game;

--- a/php/test/Test.php
+++ b/php/test/Test.php
@@ -39,9 +39,72 @@ class GameTest extends TestCase
      *
      * @param Game $game
      */
-    public function testCorrectNumberOfPlayersWhenPlayerRemoved($game) {
+    public function testCorrectNumberOfPlayersWhenPlayerRemoved($game)
+    {
         $game->remove(1);
 
-        $this->assertEquals( 2, $game->howManyPlayers());
+        $this->assertEquals(2, $game->howManyPlayers());
+    }
+
+    public function testPlayerKeepPursesWhenOtherPlayerLeaves() {
+        $game = $this->setGameFor('Katrin', 'Seraphin', 'Constantine');
+        $this->runRoundsDeterminastically($game);
+
+        $katrinPurses = $game->purses[0];
+        $constantinePurses = $game->purses[2];
+
+        $game->remove(1);
+
+        $this->assertEquals( $katrinPurses, $game->purses[0] );
+        $this->assertEquals( $constantinePurses, $game->purses[1] );
+    }
+
+    public function testPlayerKeepPlaceWhenOtherPlayerLeaves() {
+        $game = $this->setGameFor('Katrin', 'Seraphin', 'Constantine' );
+        $this->runRoundsDeterminastically($game);
+
+        $katrinPlace = $game->places[0];
+        $constantinePlace = $game->places[2];
+
+        $game->remove(1);
+
+        $this->assertEquals( $katrinPlace, $game->places[0] );
+        $this->assertEquals( $constantinePlace, $game->places[1] );
+    }
+
+    public function testPlayerStaysInPenaltyBoxWhenOtherPlayerLeaves() {
+        $game = $this->setGameFor('Katrin', 'Seraphin', 'Constantine');
+        $this->runRoundsDeterminastically($game);
+
+        $katrinInPenaltyBox = $game->inPenaltyBox[0];
+        $constantineInPenaltyBox = $game->inPenaltyBox[2];
+
+        $game->remove(1);
+
+        $this->assertEquals( $katrinInPenaltyBox, $game->inPenaltyBox[0] );
+        $this->assertEquals( $constantineInPenaltyBox, $game->inPenaltyBox[1] );
+    }
+
+    /**
+     * @return Game
+     */
+    public function setGameFor( ...$players )
+    {
+        $game = new Game();
+
+        foreach( $players as $playerName ) {
+            $game->add($playerName);
+        };
+
+        return $game;
+    }
+
+    /**
+     * @param Game $game
+     */
+    public function runRoundsDeterminastically(Game $game)
+    {
+        srand(123455);
+        GameRunner::runRounds($game, 12);
     }
 }


### PR DESCRIPTION
# Player Data Clump

## The issue

[`Game:l50-53`](https://github.com/martinsson/BugsZero-Kata/blob/50c2806a2bc1c1c91f16887988ee2ed755acd987/php/src/Game.php#L50-L53) shows an example of [Data Clump](https://en.wikipedia.org/wiki/Data_clump): these are the players related data, and each index relates to a single player. Such indices need to be consistent **across the arrays**, which can eventually lead to bugs.

[This commit](https://github.com/martinsson/BugsZero-Kata/commit/8ba3d746913ec54050e79427c4c467e77336393b) introduces a new feature: now players can leave a game while running.

As outlined in the tests from [this commit](https://github.com/martinsson/BugsZero-Kata/commit/7a43429a4aba34335a99a45b7f8f4c86fa125e92), removing a player from the `Game::players` array will mismatch the remaining players with the recorded data.

While this particular bug could be fixed by setting back the correct data in the `Game::remove()` method, now any changes on these data, or inclusion of a new type of data (for example, players may be assigned a color), would then need to be performed both in the `Game::add()` and `Game::remove()` methods. This might not be obvious to a new programmer joining the project.

## Introducing a data holding class

The solution would be to group all the data referring to a same player in a dedicated data holding instance, representing this player.

To perform this operation safely, a first step is to [encapsulate fields](https://github.com/martinsson/BugsZero-Kata/commit/5bc250f1e0d0ef26fb8224abc428e4af42544096) for `Game::players`, `Game::places`, `Game::purses` and `Game::inPenaltyBox`.

With all the data access encapsulated, we can now[move these fields](https://github.com/martinsson/BugsZero-Kata/commit/67b35a91e970a237bf30a4ad301ffdc7e0b513c3) to the `Player` class. The `Game::players` will now hold references to `Player` instances in order to access this data.

## Fixing the remove method

This refactor could have been stopped there, but the following commits outlines two new bugs that may occur when implementing the `Game::remove()` method: 

-[If a player leaves, the current player may be changed](https://github.com/martinsson/BugsZero-Kata/commit/c44a5754e8a7bc0fcede217b1cc69605c5da3e7f)
- [If the current players leaves, the current player must change to the next player](https://github.com/martinsson/BugsZero-Kata/commit/b4dc872995bbf6e7d2d3b683cc057c610f0aa4fe)

We can benefits from our players being instances here to use a reference to the current player, instead of an integer referring to its position in an array.

## Cleaning up

This could also bring an end to this refactoring, although, the encapsulation of these change of the current player offers us a good opportunity to enforce separation of concerns, by moving all the code related to selecting the current player in [a dedicated collection class](https://github.com/martinsson/BugsZero-Kata/commit/99f354cbbf3aad58e6285833c021658d6aeba8dd)

This in turn gives us the opportunity to level down all of the written tests to the `PlayersList` class scope, where the player removal feature belongs.



 
