### PR TITLE
upgrade unsupported Kotlin version

### DIFF
--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -6,7 +6,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <kotlin.version>1.2.0</kotlin.version>
+        <kotlin.version>1.4.20</kotlin.version>
     </properties>
 
 


### PR DESCRIPTION
Kotlin 1.2.0 is no longer supported and doesn't work with the latest Kotlin IDE plugin.